### PR TITLE
Add redesigned Grievance.app pricing page

### DIFF
--- a/pricing.html
+++ b/pricing.html
@@ -1,0 +1,1044 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Grievance.app Pricing</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --green-300: #55be72;
+      --green-400: #47ae5f;
+      --green-500: #00cc61;
+      --teal-900: #004050;
+      --gray-50: #f5f8f7;
+      --gray-100: #ecf3f0;
+      --gray-300: #d9e4df;
+      --gray-500: #8a9ba0;
+      --gray-700: #425155;
+      --gray-900: #111b1e;
+      --shadow-card: 0 18px 40px rgba(0, 64, 80, 0.12);
+      --shadow-hover: 0 26px 55px rgba(0, 64, 80, 0.16);
+      font-family: 'Manrope', sans-serif;
+      color: #0b1113;
+      background-color: white;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: 'Manrope', sans-serif;
+      background: linear-gradient(180deg, rgba(236, 243, 240, 0.65) 0%, rgba(255, 255, 255, 0.95) 45%);
+      color: #111b1e;
+    }
+
+    header {
+      padding: 4.5rem 1.5rem 3rem;
+      text-align: center;
+      max-width: 980px;
+      margin: 0 auto;
+    }
+
+    header .eyebrow {
+      font-size: 0.85rem;
+      letter-spacing: 0.25rem;
+      text-transform: uppercase;
+      color: var(--green-500);
+      font-weight: 700;
+      margin-bottom: 1rem;
+    }
+
+    header h1 {
+      font-size: clamp(2.5rem, 4vw, 3.5rem);
+      margin: 0 0 1.5rem;
+      color: var(--teal-900);
+      font-weight: 800;
+    }
+
+    header p {
+      font-size: 1.05rem;
+      line-height: 1.7;
+      color: var(--gray-700);
+      margin: 0 auto;
+      max-width: 750px;
+    }
+
+    .implementation-banner {
+      margin: 2.5rem auto 0;
+      max-width: 860px;
+      background: white;
+      border-radius: 18px;
+      padding: 1.25rem 1.75rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      box-shadow: var(--shadow-card);
+      border: 1px solid var(--gray-100);
+    }
+
+    .implementation-banner svg {
+      flex-shrink: 0;
+      width: 42px;
+      height: 42px;
+      color: var(--green-500);
+    }
+
+    .implementation-banner strong {
+      display: block;
+      font-weight: 700;
+      color: var(--teal-900);
+      margin-bottom: 0.25rem;
+    }
+
+    .pricing-section {
+      padding: 3rem 1.5rem 5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    .section-title {
+      text-align: center;
+      margin-bottom: 2.5rem;
+    }
+
+    .section-title h2 {
+      margin: 0;
+      font-size: clamp(2rem, 3vw, 2.75rem);
+      color: var(--teal-900);
+      font-weight: 800;
+    }
+
+    .section-title p {
+      color: var(--gray-700);
+      margin-top: 0.75rem;
+      font-size: 1.05rem;
+    }
+
+    .plan-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 1.75rem;
+    }
+
+    .plan-card {
+      background: white;
+      border-radius: 22px;
+      padding: 2.25rem 2.1rem 2.6rem;
+      box-shadow: var(--shadow-card);
+      border: 1px solid rgba(71, 174, 95, 0.12);
+      position: relative;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .plan-card.highlight {
+      border-color: var(--green-500);
+      box-shadow: var(--shadow-hover);
+    }
+
+    .plan-card::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: radial-gradient(circle at top right, rgba(85, 190, 114, 0.12), transparent 55%);
+      pointer-events: none;
+    }
+
+    .plan-header {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-bottom: 1.75rem;
+      position: relative;
+      z-index: 1;
+    }
+
+    .plan-name {
+      font-size: 1.15rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.16rem;
+      color: var(--green-400);
+    }
+
+    .plan-card.highlight .plan-name {
+      color: var(--teal-900);
+    }
+
+    .plan-tagline {
+      font-size: 1.5rem;
+      color: var(--teal-900);
+      font-weight: 800;
+      margin: 0;
+    }
+
+    .plan-price {
+      display: flex;
+      align-items: baseline;
+      gap: 0.4rem;
+      font-weight: 700;
+      color: var(--teal-900);
+    }
+
+    .plan-price .amount {
+      font-size: 2.4rem;
+    }
+
+    .plan-price .term {
+      font-size: 1rem;
+      color: var(--gray-500);
+      font-weight: 600;
+    }
+
+    .feature-list {
+      margin: 0 0 2.25rem;
+      padding: 0;
+      list-style: none;
+      display: grid;
+      gap: 1rem;
+      position: relative;
+      z-index: 1;
+    }
+
+    .feature-item {
+      display: grid;
+      grid-template-columns: 28px 1fr;
+      gap: 0.85rem;
+      align-items: flex-start;
+    }
+
+    .feature-item strong {
+      display: block;
+      font-weight: 700;
+      color: var(--teal-900);
+      margin-bottom: 0.15rem;
+    }
+
+    .feature-item span {
+      font-size: 0.98rem;
+      color: var(--gray-700);
+      line-height: 1.5;
+    }
+
+    .icon-circle {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: rgba(0, 204, 97, 0.12);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--green-500);
+      font-weight: 700;
+      font-size: 0.9rem;
+    }
+
+    .plan-card button {
+      padding: 0.95rem 1.2rem;
+      border: none;
+      border-radius: 999px;
+      background: var(--green-500);
+      color: white;
+      font-weight: 700;
+      font-size: 1rem;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      position: relative;
+      z-index: 1;
+    }
+
+    .plan-card button:hover {
+      background: var(--green-300);
+      transform: translateY(-2px);
+      box-shadow: 0 10px 20px rgba(0, 64, 80, 0.16);
+    }
+
+    .plan-card .disclaimer {
+      margin-top: 1.4rem;
+      font-size: 0.92rem;
+      color: var(--gray-500);
+      text-align: center;
+    }
+
+    .comparison-table {
+      margin-top: 4.5rem;
+      background: white;
+      border-radius: 24px;
+      border: 1px solid var(--gray-100);
+      box-shadow: var(--shadow-card);
+      overflow: hidden;
+    }
+
+    .comparison-table table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.98rem;
+    }
+
+    .comparison-table thead {
+      background: var(--teal-900);
+      color: white;
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      padding: 1.1rem 1.25rem;
+      text-align: left;
+      border-bottom: 1px solid var(--gray-100);
+    }
+
+    .comparison-table th:first-child,
+    .comparison-table td:first-child {
+      background: rgba(236, 243, 240, 0.4);
+      font-weight: 700;
+      color: var(--teal-900);
+    }
+
+    .comparison-table tbody tr:nth-child(even) td {
+      background: rgba(245, 248, 247, 0.65);
+    }
+
+    .comparison-table .check {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 600;
+      color: var(--teal-900);
+    }
+
+    .comparison-table .check svg {
+      width: 16px;
+      height: 16px;
+      color: var(--green-400);
+    }
+
+    .comparison-table .dash {
+      color: var(--gray-500);
+      font-weight: 600;
+    }
+
+    .add-ons {
+      margin-top: 4.5rem;
+    }
+
+    .add-on-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1.6rem;
+    }
+
+    .add-on-card {
+      background: white;
+      border-radius: 20px;
+      padding: 1.85rem;
+      border: 1px solid var(--gray-100);
+      box-shadow: 0 8px 25px rgba(0, 64, 80, 0.08);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .add-on-card h3 {
+      margin: 0;
+      font-size: 1.2rem;
+      color: var(--teal-900);
+      font-weight: 700;
+    }
+
+    .add-on-card p {
+      margin: 0;
+      color: var(--gray-700);
+      line-height: 1.55;
+      font-size: 0.98rem;
+    }
+
+    .add-on-card .pricing {
+      font-weight: 700;
+      color: var(--teal-900);
+    }
+
+    .add-on-card button {
+      align-self: flex-start;
+      background: transparent;
+      border: 1.5px solid var(--green-500);
+      color: var(--teal-900);
+      padding: 0.7rem 1.4rem;
+      border-radius: 999px;
+      font-weight: 700;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    }
+
+    .add-on-card button:hover {
+      background: var(--green-500);
+      color: white;
+      transform: translateY(-2px);
+    }
+
+    .faq-section {
+      margin-top: 5rem;
+      background: rgba(0, 64, 80, 0.06);
+      border-radius: 26px;
+      padding: 3.2rem 3rem;
+    }
+
+    .faq-section h2 {
+      margin: 0 0 1.75rem;
+      font-size: 2.1rem;
+      color: var(--teal-900);
+      font-weight: 800;
+      text-align: center;
+    }
+
+    .faq-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1.5rem;
+    }
+
+    details {
+      background: white;
+      border-radius: 18px;
+      padding: 1.4rem 1.6rem;
+      border: 1px solid rgba(71, 174, 95, 0.12);
+      box-shadow: 0 6px 18px rgba(0, 64, 80, 0.08);
+    }
+
+    summary {
+      font-weight: 700;
+      font-size: 1.02rem;
+      color: var(--teal-900);
+      cursor: pointer;
+      list-style: none;
+      position: relative;
+      padding-right: 1.5rem;
+    }
+
+    summary::marker {
+      display: none;
+    }
+
+    summary::after {
+      content: '+';
+      position: absolute;
+      right: 0;
+      top: 0;
+      font-size: 1.5rem;
+      color: var(--green-400);
+      transition: transform 0.3s ease;
+    }
+
+    details[open] summary::after {
+      transform: rotate(45deg);
+    }
+
+    details p {
+      margin: 0.9rem 0 0;
+      color: var(--gray-700);
+      line-height: 1.6;
+      font-size: 0.98rem;
+    }
+
+    .cta-final {
+      margin: 5rem auto 4rem;
+      max-width: 960px;
+      background: linear-gradient(120deg, rgba(0, 64, 80, 0.96), rgba(0, 204, 97, 0.95));
+      border-radius: 28px;
+      padding: 3.4rem 3rem;
+      color: white;
+      text-align: center;
+      box-shadow: var(--shadow-hover);
+    }
+
+    .cta-final h2 {
+      margin: 0 0 1rem;
+      font-size: clamp(2rem, 3vw, 2.6rem);
+      font-weight: 800;
+    }
+
+    .cta-final p {
+      margin: 0 0 2rem;
+      font-size: 1.05rem;
+      line-height: 1.6;
+    }
+
+    .cta-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 1rem;
+    }
+
+    .cta-actions a {
+      text-decoration: none;
+      font-weight: 700;
+      padding: 0.9rem 1.9rem;
+      border-radius: 999px;
+      border: 2px solid white;
+      color: white;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .cta-actions a.primary {
+      background: white;
+      color: var(--teal-900);
+    }
+
+    .cta-actions a.primary:hover {
+      background: rgba(255, 255, 255, 0.9);
+    }
+
+    .cta-actions a.secondary:hover {
+      background: rgba(255, 255, 255, 0.15);
+    }
+
+    footer {
+      text-align: center;
+      color: var(--gray-500);
+      font-size: 0.9rem;
+      padding: 0 0 2.5rem;
+    }
+
+    @media (max-width: 1024px) {
+      .plan-grid {
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      }
+
+      .add-on-grid,
+      .faq-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .implementation-banner {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+    }
+
+    @media (max-width: 720px) {
+      header {
+        padding-top: 3.5rem;
+      }
+
+      .plan-card {
+        padding: 2rem 1.75rem;
+      }
+
+      .comparison-table table {
+        font-size: 0.92rem;
+      }
+
+      .comparison-table th,
+      .comparison-table td {
+        padding: 1rem;
+      }
+
+      .cta-final {
+        padding: 2.8rem 2.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">Pricing Overview</div>
+    <h1>Enterprise-Grade Grievance Management for Every Organization</h1>
+    <p>
+      Explore Grievance.app’s tiered subscription plans, each designed to align with the scale of your operations. From foundational capabilities to fully customized deployments, every option includes the core grievance management engine you need to modernize intake, tracking, and resolution.
+    </p>
+    <div class="implementation-banner">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 3v18" />
+        <path d="M5 12h14" />
+        <path d="M19 21V9.5L12 4 5 9.5V21" />
+      </svg>
+      <div>
+        <strong>One-Time Implementation Fee &mdash; $25,000</strong>
+        Deployment includes dedicated-cloud setup, configuration, data migration, and comprehensive training so your team launches successfully with no hidden costs.
+      </div>
+    </div>
+  </header>
+
+  <main class="pricing-section">
+    <div class="section-title">
+      <h2>Select the Right Annual Plan</h2>
+      <p>Compare the Standard, Enhanced, and Enterprise subscriptions to determine which package aligns with your governance, support, and customization requirements.</p>
+    </div>
+
+    <div class="plan-grid">
+      <article class="plan-card">
+        <div class="plan-header">
+          <span class="plan-name">Standard</span>
+          <h3 class="plan-tagline">Essential coverage for focused teams</h3>
+          <div class="plan-price">
+            <span class="amount">$8,000</span>
+            <span class="term">per year</span>
+          </div>
+        </div>
+        <ul class="feature-list">
+          <li class="feature-item">
+            <div class="icon-circle">CM</div>
+            <div>
+              <strong>Core Case Management</strong>
+              <span>Streamlined intake, tracking, and reporting capabilities for consistent resolution of every grievance.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">URL</div>
+            <div>
+              <strong>Custom Sub-Domain</strong>
+              <span>Launch on <em>yourorganization.grievance.app</em> to establish recognizable branding from day one.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">SUP</div>
+            <div>
+              <strong>Technical Support</strong>
+              <span>Email/ticketing support during business hours ensures responsive troubleshooting and guidance.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">WEB</div>
+            <div>
+              <strong>Web Access Only</strong>
+              <span>Mobile apps are not included at this tier; the responsive web portal covers essential usage.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">CFG</div>
+            <div>
+              <strong>Out-of-the-Box Configuration</strong>
+              <span>Deploy quickly with your logo and standard workflow; deeper customization is available in higher tiers.</span>
+            </div>
+          </li>
+        </ul>
+        <button type="button">Get Started</button>
+        <p class="disclaimer">Annual subscription billed in advance. Implementation fee applies once.</p>
+      </article>
+
+      <article class="plan-card highlight">
+        <div class="plan-header">
+          <span class="plan-name">Enhanced</span>
+          <h3 class="plan-tagline">Advanced capabilities with priority guidance</h3>
+          <div class="plan-price">
+            <span class="amount">$15,000</span>
+            <span class="term">per year</span>
+          </div>
+        </div>
+        <ul class="feature-list">
+          <li class="feature-item">
+            <div class="icon-circle">ALL</div>
+            <div>
+              <strong>All Standard Features</strong>
+              <span>Retain every foundational capability, and unlock deeper analytics, branding, and integration readiness.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">TPL</div>
+            <div>
+              <strong>Template Library Access</strong>
+              <span>Operationalize faster with curated report and communication templates designed for grievance teams.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">BRD</div>
+            <div>
+              <strong>Custom Branding</strong>
+              <span>Personalize your portal URL and visual theming to mirror your organization’s identity.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">API</div>
+            <div>
+              <strong>Analytics &amp; Integrations</strong>
+              <span>Benefit from enhanced reporting plus open API access to connect with complementary systems.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">MOB</div>
+            <div>
+              <strong>Mobile-Responsive Access</strong>
+              <span>Stay productive via web and Android devices; dedicated iOS app support is reserved for Enterprise.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">CFG</div>
+            <div>
+              <strong>Moderate Customization</strong>
+              <span>Configure workflows and fields for your processes, while bespoke development awaits the Enterprise tier.</span>
+            </div>
+          </li>
+        </ul>
+        <button type="button">Get Started</button>
+        <p class="disclaimer">Annual subscription billed in advance. Implementation fee applies once.</p>
+      </article>
+
+      <article class="plan-card">
+        <div class="plan-header">
+          <span class="plan-name">Enterprise</span>
+          <h3 class="plan-tagline">Complete platform with tailored delivery</h3>
+          <div class="plan-price">
+            <span class="amount">$25,000</span>
+            <span class="term">per year</span>
+          </div>
+        </div>
+        <ul class="feature-list">
+          <li class="feature-item">
+            <div class="icon-circle">PLUS</div>
+            <div>
+              <strong>Includes Enhanced Features</strong>
+              <span>All Enhanced plan capabilities are included, alongside Enterprise-exclusive benefits.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">APP</div>
+            <div>
+              <strong>Mobile Applications</strong>
+              <span>Provide Android and iOS apps for staff and stakeholders to submit and manage cases anywhere.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">SEC</div>
+            <div>
+              <strong>Advanced Security &amp; Performance</strong>
+              <span>Enterprise-grade security, load balancing, and performance tuning support large-scale deployments.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">CST</div>
+            <div>
+              <strong>Full Customization</strong>
+              <span>Shape workflows, data structures, and interfaces to mirror your institution’s exact requirements.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">AM</div>
+            <div>
+              <strong>Dedicated Account Manager</strong>
+              <span>Partner with a named advisor who coordinates proactive strategy, adoption, and best practices.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">SLA</div>
+            <div>
+              <strong>Priority Support</strong>
+              <span>24/7 escalation paths and fastest response times ensure mission-critical incidents are resolved quickly.</span>
+            </div>
+          </li>
+          <li class="feature-item">
+            <div class="icon-circle">ADV</div>
+            <div>
+              <strong>Advanced Features</strong>
+              <span>Unlock premium modules such as confidential GBV workflows, offline access, and advanced integrations.</span>
+            </div>
+          </li>
+        </ul>
+        <button type="button">Get Started</button>
+        <p class="disclaimer">Annual subscription billed in advance. Implementation fee applies once.</p>
+      </article>
+    </div>
+
+    <section class="comparison-table" aria-labelledby="comparison-heading">
+      <table>
+        <thead>
+          <tr>
+            <th scope="col" id="comparison-heading">Feature</th>
+            <th scope="col">Standard</th>
+            <th scope="col">Enhanced</th>
+            <th scope="col">Enterprise</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Annual Subscription Fee</td>
+            <td>$8,000/year</td>
+            <td>$15,000/year</td>
+            <td>$25,000/year</td>
+          </tr>
+          <tr>
+            <td>One-Time Setup Fee (all plans)</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              $25,000 ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              $25,000 ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              $25,000 ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Core Case Management</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Basic
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Enhanced
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Enhanced
+            </td>
+          </tr>
+          <tr>
+            <td>API Access for Integrations</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Standard Reports &amp; Analytics</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Advanced Analytics</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Pre-Built Template Documents</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Custom Sub-Domain (Branded URL)</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Dedicated Android Mobile App</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Dedicated iOS Mobile App</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Advanced Security Options</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Basic
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Standard
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓ Enhanced
+            </td>
+          </tr>
+          <tr>
+            <td>High-Performance Infrastructure</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Basic Configuration &amp; Branding</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Extensive Customization</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Standard Support (Email)</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+            <td class="dash">&ndash; (Elevated)</td>
+          </tr>
+          <tr>
+            <td>Priority Support &amp; SLA</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+          <tr>
+            <td>Dedicated Account Manager</td>
+            <td class="dash">&ndash;</td>
+            <td class="dash">&ndash;</td>
+            <td class="check">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+              ✓
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="add-ons" aria-labelledby="addons-heading">
+      <div class="section-title">
+        <h2 id="addons-heading">Optional Add-On Modules</h2>
+        <p>Extend your platform with specialized modules that enhance citizen access, secure workflows, and system interoperability.</p>
+      </div>
+      <div class="add-on-grid">
+        <article class="add-on-card">
+          <h3>IVR Integration (Telephone Hotline)</h3>
+          <p class="pricing">One-time $15,000 setup + $3,000/year</p>
+          <p>Launch a toll-free hotline where callers submit grievances through touch-tone or voice prompts. Submissions sync instantly into Grievance.app for unified case tracking.</p>
+          <button type="button">Add to Plan</button>
+        </article>
+        <article class="add-on-card">
+          <h3>SMS Submission &amp; Alerts</h3>
+          <p class="pricing">One-time $7,500 setup + $1,500/year</p>
+          <p>Enable two-way SMS so constituents can file new cases and receive automated updates by text. Ideal for quick acknowledgments and progress notifications.</p>
+          <button type="button">Add to Plan</button>
+        </article>
+        <article class="add-on-card">
+          <h3>GBV Workflow Module</h3>
+          <p class="pricing">One-time $10,000 setup + $2,000/year</p>
+          <p>Introduce confidential pathways for Gender-Based Violence cases with specialized data fields, role-based access, and compliance-aligned handling.</p>
+          <button type="button">Add to Plan</button>
+        </article>
+        <article class="add-on-card">
+          <h3>Offline Access Capability</h3>
+          <p class="pricing">One-time $20,000 setup + $5,000/year</p>
+          <p>Equip field teams with an offline-enabled app that securely syncs captured grievances once connectivity resumes.</p>
+          <button type="button">Add to Plan</button>
+        </article>
+        <article class="add-on-card">
+          <h3>Third-Party System Integration</h3>
+          <p class="pricing">$10,000 setup per integration + $2,000/year per integration</p>
+          <p>Connect Grievance.app with government MIS, CRM, or call center platforms for seamless bidirectional data exchange tailored to your tech stack.</p>
+          <button type="button">Add to Plan</button>
+        </article>
+      </div>
+    </section>
+
+    <section class="faq-section" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">Frequently Asked Questions</h2>
+      <div class="faq-grid">
+        <details>
+          <summary>Can I upgrade or downgrade plans later?</summary>
+          <p>Yes. Your subscription can be adjusted at any time, and we apply prorated credits so you only pay for the time used at each tier.</p>
+        </details>
+        <details>
+          <summary>Is there a free trial or demo available?</summary>
+          <p>We provide guided demonstrations and a sandbox environment upon request so your stakeholders can experience the platform before committing.</p>
+        </details>
+        <details>
+          <summary>How is our data secured within Grievance.app?</summary>
+          <p>Grievance.app employs encryption in transit and at rest, frequent backups, and rigorous access controls that align with enterprise data protection standards.</p>
+        </details>
+        <details>
+          <summary>What is included in the implementation fee?</summary>
+          <p>The $25,000 onboarding package covers dedicated-cloud provisioning, configuration, data migration, branding, and comprehensive administrator/end-user training.</p>
+        </details>
+        <details>
+          <summary>Can we add bespoke integrations for external systems?</summary>
+          <p>Absolutely. Use the Third-Party System Integration add-on to scope, build, and support tailored connections to your existing technology ecosystem.</p>
+        </details>
+        <details>
+          <summary>Do you offer support coverage around the clock?</summary>
+          <p>Enterprise clients receive 24/7 priority support with the fastest response times, while Standard and Enhanced tiers include business-hours assistance.</p>
+        </details>
+      </div>
+    </section>
+
+    <section class="cta-final">
+      <h2>Ready to transform your grievance management process?</h2>
+      <p>Select the plan that aligns with your oversight needs or speak with our team for a tailored proposal. We’re here to guide your rollout from consultation to sustained adoption.</p>
+      <div class="cta-actions">
+        <a href="#" class="primary">Get Started Now</a>
+        <a href="#" class="secondary">Contact Sales</a>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    Consistency assured: pricing, features, and descriptions align with the official Grievance.app technical and financial proposals.
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone pricing.html page for Grievance.app with Manrope typography and brand colors
- highlight Standard, Enhanced, and Enterprise plans with detailed feature descriptions and CTAs
- incorporate comparison table, add-on modules, FAQs, and final CTA in a responsive layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d80335b2c883238692174dddf2072a